### PR TITLE
Nurf nxdata

### DIFF
--- a/examples/loki/LOKI_geometry.py
+++ b/examples/loki/LOKI_geometry.py
@@ -9,7 +9,7 @@ import random
 from enum import Enum
 from typing import Dict, List, Optional
 from nurf_data import load_one_spectro_file, nurf_file_creator
-IMPORT_LARMOR = True  # Change depending on what data set should be used.
+IMPORT_LARMOR = False  # Change depending on what data set should be used.
 DEBUG_LARMOR_DET = False  #
 if IMPORT_LARMOR:
     from larmor_data import FRACTIONAL_PRECISION, \
@@ -1054,7 +1054,7 @@ if __name__ == '__main__':
     generate_nexus_content_into_csv = False
     generate_nexus_content_into_nxs = True
     add_data_to_nxs = False
-    add_nurf_to_nxs = False
+    add_nurf_to_nxs = True
     # bank_ids_transform_as_nxlog = [n for n in range(0, 9)]
     bank_ids_transform_as_nxlog = [-1]
     detector_banks: List[Bank] = []

--- a/examples/loki/nurf_data.py
+++ b/examples/loki/nurf_data.py
@@ -160,6 +160,12 @@ def nurf_file_creator(loki_file, path_to_loki_file, data):
         grp_uv.attrs['spectrum_key_indices'] = 0
         grp_uv.attrs['integration_time_indices'] = 0
         grp_uv.attrs['wavelength_indices'] = 1
+
+        # introducing a key that is interpretable for sample, dark, and reference 
+        grp_uv.attrs['is_sample_indices'] = 0
+        grp_uv.attrs['is_dark_indices'] = 0
+        grp_uv.attrs['is_reference_indices'] = 0  
+
         
         # uv_spectrum_key
         uv_signal_image_key=grp_uv.create_dataset('spectrum_key',data=uv_spectrum_key, dtype=np.int32)
@@ -248,6 +254,7 @@ def nurf_file_creator(loki_file, path_to_loki_file, data):
         grp_fluo.attrs['spectrum_key_indices'] = 0
         grp_fluo.attrs['integration_time_indices'] = 0
         grp_fluo.attrs['wavelength_indices'] = 1
+
         
         fluo_signal_image_key=grp_fluo.create_dataset('spectrum_key',data=fluo_spectrum_key, dtype=np.int32)
        

--- a/examples/loki/nurf_data.py
+++ b/examples/loki/nurf_data.py
@@ -235,7 +235,7 @@ def nurf_file_creator(loki_file, path_to_loki_file, data):
         # fluo spectra
         fluo_signal_data = grp_fluo.create_dataset('data',
                                                data=fluo_all_data, dtype=np.float32)
-        fluo_signal_data.attrs['long name'] = 'fluo_all_data'
+        fluo_signal_data.attrs['long name'] = 'all_data'
         fluo_signal_data.attrs['units'] = 'a.u.'
     
 
@@ -243,12 +243,12 @@ def nurf_file_creator(loki_file, path_to_loki_file, data):
         grp_fluo.attrs['axes']= [ "time", "wavelength"]
         
         # define the AXISNAME_indices
-        grp_fluo.attrs['fluo_time_indices'] = 0
-        grp_fluo.attrs['fluo_spectrum_key_indices'] = 0
-        grp_fluo.attrs['fluo_integration_time_indices'] = 0
-        grp_fluo.attrs['fluo_wavelength_indices'] = 1
+        grp_fluo.attrs['time_indices'] = 0
+        grp_fluo.attrs['spectrum_key_indices'] = 0
+        grp_fluo.attrs['integration_time_indices'] = 0
+        grp_fluo.attrs['wavelength_indices'] = 1
         
-        fluo_signal_image_key=grp_fluo.create_dataset('fluo_spectrum_key',data=fluo_spectrum_key, dtype=np.int32)
+        fluo_signal_image_key=grp_fluo.create_dataset('spectrum_key',data=fluo_spectrum_key, dtype=np.int32)
        
         # fluo_time
         # dummy timestamps for fluo_time
@@ -259,7 +259,7 @@ def nurf_file_creator(loki_file, path_to_loki_file, data):
     
         # see https://stackoverflow.com/questions/23570632/store-datetimes-in-hdf5-with-h5py 
         # suggested work around because h5py does not support time types
-        fluo_time_data=grp_fluo.create_dataset('fluo_time', data=fluo_time.view('<i8'), dtype='<i8')
+        fluo_time_data=grp_fluo.create_dataset('time', data=fluo_time.view('<i8'), dtype='<i8')
         # to read
         #print(fluo_time_data[:].view('<M8[us]'))
         # TODO: Do we need here an attribute for the unit?
@@ -270,24 +270,24 @@ def nurf_file_creator(loki_file, path_to_loki_file, data):
         fluo_inttime=np.full(np.shape(fluo_spectrum_key),data['Fluo_IntegrationTime'])
        
         # fluo_integration_time
-        fluo_inttime_data = grp_fluo.create_dataset('fluo_integration_time',
+        fluo_inttime_data = grp_fluo.create_dataset('integration_time',
                                                data=fluo_inttime,
                                                dtype=np.float32)
         fluo_inttime_data.attrs['units'] = 'us'  # TODO: unit to be verified, currently micro-seconds
-        fluo_inttime_data.attrs['long name'] = 'fluo_integration_time'
+        fluo_inttime_data.attrs['long name'] = 'integration_time'
 
 
         # fluo_monowavelengths
-        fluo_monowavelengths_data = grp_fluo.create_dataset('fluo_monowavelengths',
+        fluo_monowavelengths_data = grp_fluo.create_dataset('monowavelengths',
                                                        data=data[
                                                            'Fluo_monowavelengths'],
                                                        dtype=np.float32)
         fluo_monowavelengths_data.attrs['units'] = 'nm'  # TODO: unit to be verified
-        fluo_monowavelengths_data.attrs['long name'] = 'fluo_monowavelengths'
+        fluo_monowavelengths_data.attrs['long name'] = 'monowavelengths'
 
         
         # fluo_wavelength
-        fluo_wavelength_data= grp_fluo.create_dataset('fluo_wavelength',
+        fluo_wavelength_data= grp_fluo.create_dataset('wavelength',
                                                   data=data['Fluo_wavelength'],
                                                   dtype=np.float32)
         fluo_wavelength_data.attrs['units'] = 'nm'  # TODO: unit to be verified

--- a/examples/loki/nurf_data.py
+++ b/examples/loki/nurf_data.py
@@ -2,7 +2,7 @@ import errno
 import os
 import h5py
 import numpy as np
-
+import copy 
 
 def load_one_spectro_file(file_handle, path_rawdata):
     """
@@ -117,6 +117,43 @@ def nurf_file_creator(loki_file, path_to_loki_file, data):
         # assemble all spectra in one variable
         uv_all_data=np.row_stack((data['UV_spectra'],data['UV_background'], data['UV_intensity0']))
       
+        print(uv_all_data.size)
+        print(uv_all_data.ndim)
+        print(np.shape(uv_all_data))
+
+        dummy_vec=np.full(np.shape(uv_all_data)[0], False) 
+        lidx=np.arange(0,np.shape(uv_all_data)[0])
+        print(dummy_vec, lidx)
+
+        #create boolean masks for data, dark, reference
+        uv_nb_spectra=np.shape(data['UV_spectra'])[0]
+
+        # data mask, copy and replace first entries 
+        uv_data_mask=copy.copy(dummy_vec)
+        uv_data_mask[0:uv_nb_spectra]=True
+
+        # dark mask
+        # find out how many darks exist
+        # TODO: Is there always a background or do we need to catch this case if there isn't?
+        if data['UV_background'].ndim==1:
+            uv_nb_darks=1
+        else: 
+            uv_nb_darks=np.shape(data['UV_background'])[1]  #TODO: needs to be verified with real data from Judith's setup
+
+        uv_dark_mask=copy.copy(dummy_vec)
+        uv_dark_mask[uv_nb_spectra:uv_nb_spectra+uv_nb_darks]=True
+
+        # reference 
+        # how many references where taken? 
+        if data['UV_intensity0'].ndim==1:
+            uv_nb_ref=1
+        else:
+            uv_nb_ref=np.shape(data['UV_intensity0'])[1]  #TODO: needs to be verified with real data from Judith's setup
+        
+        # reference mask, copy and replace first entries 
+        uv_ref_mask=copy.copy(dummy_vec)
+        uv_ref_mask[uv_nb_spectra+uv_nb_darks:uv_nb_spectra+uv_nb_darks+uv_nb_ref]=True
+
         
         # assemble image_key 
         # #TODO: needs later to be verified with real data from hardware

--- a/examples/loki/nurf_data.py
+++ b/examples/loki/nurf_data.py
@@ -178,9 +178,7 @@ def nurf_file_creator(loki_file, path_to_loki_file, data):
         grp_uv.attrs['is_reference_indices'] = 0  
 
         
-        # uv_spectrum_key
-        uv_signal_image_key=grp_uv.create_dataset('spectrum_key',data=uv_spectrum_key, dtype=np.int32)
-        
+
         # uv_time
         # dummy timestamps for uv_time
         # TODO: Codes will have to change later for the real hardware.

--- a/examples/loki/nurf_data.py
+++ b/examples/loki/nurf_data.py
@@ -270,9 +270,9 @@ def nurf_file_creator(loki_file, path_to_loki_file, data):
         grp_fluo.attrs['integration_time_indices'] = 0
         grp_fluo.attrs['wavelength_indices'] = 1
 
-        grp_fluo.attrs['is_data'] = 0
-        grp_fluo.attrs['is_dark'] = 0
-        grp_fluo.attrs['is_reference'] = 0  
+        grp_fluo.attrs['is_data_indices'] = 0
+        grp_fluo.attrs['is_dark_indices'] = 0
+        grp_fluo.attrs['is_reference_indices'] = 0  
 
         grp_fluo.create_dataset('is_data',data=fluo_data_mask,dtype=bool)
         grp_fluo.create_dataset('is_dark',data=fluo_dark_mask,dtype=bool)

--- a/examples/loki/nurf_data.py
+++ b/examples/loki/nurf_data.py
@@ -107,115 +107,163 @@ def nurf_file_creator(loki_file, path_to_loki_file, data):
         #print(list(hf['/entry/'].keys()))
         
         # create the various subgrous and their attributes
-
+        
         # UV subgroup
         grp_uv = hf.create_group("/entry/instrument/uv")
-        grp_uv.attrs["NX_class"] = 'NXdetector'
-        grp_uv.create_dataset('description', data='UV')
-        grp_uv.create_dataset('type',
-                              data='HR4PRO-UV-VIS-ES, DH-2000-FHS-DUV-TTL, QP600-2-SR')
+        grp_uv.attrs["NX_class"] = 'NXdetector_group'
+        
+        # subgroup for uv_spectra
+        uv_spectra=grp_uv.create_group("uv_spectra")
+        uv_spectra.attrs["NX_class"] = 'NXdetector'
+        uv_spectra_data=uv_spectra.create_dataset('data', data=data['UV_spectra'],
+                                           shape=data[
+                                               'UV_spectra'].shape,
+                                           dtype=np.int32)
+        uv_spectra_data.attrs['long_name']= 'uv_spectra'
+        uv_spectra_data.attrs['units']= 'a.u.'
+        
+        # How to write type from NXdetector? 
+        # type: (optional) NX_CHAR
+        # Description of type such as He3 gas cylinder, He3 PSD, scintillator, fission chamber, proportion counter, ion
+        # chamber, ccd, pixel, image plate, CMOS, ...
+
+        # Like this?
+        string_dt = h5py.special_dtype(vlen=str)
+        uv_spectra_type=uv_spectra.create_dataset('type', data='ccd', dtype=string_dt)
+        uv_spectra_type.attrs['type']='ccd'
+
     
-        # create the various datasets for UV
-        uv_inttime = grp_uv.create_dataset('uv_integration_time',
+        # subgroup for uv_integration time
+        uv_inttime=grp_uv.create_group("uv_integration_time")
+        uv_inttime.attrs["NX_class"] = 'NXdetector'
+    
+        uv_inttime_data=uv_inttime.create_dataset('uv_integration_time',
                                            data=data['UV_IntegrationTime'],
                                            shape=data[
                                                'UV_IntegrationTime'].shape,
                                            dtype=np.int32)
-        uv_inttime.attrs['long_name'] = 'uv_integration_time'
-        uv_inttime.attrs['units'] = 's'  # TODO: unit to be verified
+        uv_inttime_data.attrs['long_name'] = 'uv_integration_time'
+        uv_inttime_data.attrs['units'] = 's'  # TODO: unit to be verified
 
-        uv_bkg = grp_uv.create_dataset('uv_background',
+        # subgroup for uv_background
+        uv_bkg=grp_uv.create_group("uv_background")
+        uv_bkg.attrs["NX_class"] = 'NXdetector'
+
+        uv_bkg_data = uv_bkg.create_dataset('data',
                                        data=data['UV_background'],
                                        shape=data['UV_background'].shape,
                                        dtype=np.float32)
-        uv_bkg.attrs['long name'] = 'uv_background'
+        uv_bkg_data.attrs['long name'] = 'uv_background'
+        uv_bkg_data.attrs['data'] = 'a.u.'
 
-        uv_int0 = grp_uv.create_dataset('uv_intensity0',
-                                        data=data['UV_intensity0'],
-                                        shape=data['UV_intensity0'].shape,
-                                        dtype=np.float32)
-        uv_int0.attrs['long name'] = 'uv_intensity0'
+        # subgroup for uv_intensity0
+        uv_int0=grp_uv.create_group("uv_intensity0")
+        uv_int0.attrs["NX_class"] = 'NXdetector'
+        uv_int0_data = uv_int0.create_dataset('data', data=data['UV_intensity0'], 
+                                            shape=data['UV_intensity0'].shape, 
+                                            dtype=np.float32)
+        uv_int0_data.attrs['long name'] = 'uv_intensity0'
+        uv_int0_data.attrs['units'] = 'a.u.'
 
-        uv_spectra = grp_uv.create_dataset('uv_spectra',
-                                           data=data['UV_spectra'],
-                                           shape=data['UV_spectra'].shape,
-                                           dtype=np.float32)
-        uv_spectra.attrs['long name'] = 'uv_spectra'
-
-        uv_wavelength = grp_uv.create_dataset('uv_wavelength',
+        
+        # subgroup for uv_wavelength
+        uv_wavelength=grp_uv.create_group("uv_wavelength")
+        uv_wavelength.attrs["NX_class"] = 'NXdetector'
+        
+        uv_wavelength_data = uv_wavelength.create_dataset('data',
                                               data=data['UV_wavelength'],
                                               shape=data['UV_wavelength'].shape,
                                               dtype=np.float32)
-        uv_wavelength.attrs['units'] = 'nm'  # TODO: unit to be verified
-        uv_wavelength.attrs['long name'] = 'uv_wavelength'
+        uv_wavelength_data.attrs['units'] = 'nm'  # TODO: unit to be verified
+        uv_wavelength_data.attrs['long name'] = 'uv_wavelength'
 
         # Fluorescence subgroup
         grp_fluo = hf.create_group("/entry/instrument/fluorescence")
-        grp_fluo.attrs["NX_class"] = 'NXdetector'
-        # grp_fluo.attrs["description"] = 'Fluorescence'
-        # grp_fluo.attrs["Fluo lightsource"] = 'LSM-265A,-310A with LDC-1'
-        grp_fluo.create_dataset('description', data='LSM-265A,-310A with LDC-1')
-
-        # create the various datasets for fluo
-        fluo_inttime = grp_fluo.create_dataset('fluo_integration_time',
-                                               data=data[
-                                                   'Fluo_IntegrationTime'],
-                                               shape=data[
-                                                   'Fluo_IntegrationTime'].shape,
+        grp_fluo.attrs["NX_class"] = 'NXdetector_group'
+        
+        
+        # subgroup for fluo_integration_time
+        fluo_inttime=grp_fluo.create_group("fluo_integration_time")
+        fluo_inttime.attrs["NX_class"] = 'NXdetector'
+        
+        fluo_inttime_data = fluo_inttime.create_dataset('fluo_integration_time',
+                                               data=data['Fluo_IntegrationTime'],
+                                               shape=data['Fluo_IntegrationTime'].shape,
                                                dtype=np.int32)
-        fluo_inttime.attrs['units'] = 's'  # TODO: unit to be verified
-        fluo_inttime.attrs['long name'] = 'fluo_integration_time'
+        fluo_inttime_data.attrs['units'] = 's'  # TODO: unit to be verified
+        fluo_inttime_data.attrs['long name'] = 'fluo_integration_time'
 
-        fluo_bkg = grp_fluo.create_dataset('fluo_background',
+
+        # subgroup for fluo_bkg
+        fluo_bkg=grp_fluo.create_group("fluo_background")
+        fluo_bkg.attrs["NX_class"] = 'NXdetector'
+        fluo_bkg_data = fluo_bkg.create_dataset('fluo_background',
                                            data=data['Fluo_background'],
                                            shape=data['Fluo_background'].shape,
                                            dtype=np.float32)
-        fluo_bkg.attrs['long name'] = 'fluo_background'
+        fluo_bkg_data.attrs['long name'] = 'fluo_background'
+        fluo_bkg_data.attrs['unit'] = 'a.u.'
 
-        fluo_int0 = grp_fluo.create_dataset('fluo_intensity0',
+        # subgroup for fluo_intensity0
+        fluo_int0=grp_fluo.create_group("fluo_intensity0")
+        fluo_int0.attrs["NX_class"] = 'NXdetector'
+        fluo_int0_data = fluo_int0.create_dataset('fluo_intensity0',
                                             data=data['Fluo_intensity0'],
                                             shape=data['Fluo_intensity0'].shape,
                                             dtype=np.float32)
-        fluo_int0.attrs['long name'] = 'fluo_intensity0'
+        fluo_int0_data.attrs['long name'] = 'fluo_intensity0'
+        fluo_int0_data.attrs['units'] = 'a.u.'
 
-        fluo_monowavelengths = grp_fluo.create_dataset('fluo_monowavelengths',
+
+        # subgroup for fluo_monowavelengths
+        fluo_monowavelengths=grp_fluo.create_group("fluo_monowavelengths")
+        fluo_monowavelengths.attrs["NX_class"] = 'NXdetector'
+        fluo_monowavelengths_data = fluo_monowavelengths.create_dataset('fluo_monowavelengths',
                                                        data=data[
                                                            'Fluo_monowavelengths'],
                                                        shape=data[
                                                            'Fluo_monowavelengths'].shape,
                                                        dtype=np.float32)
-        fluo_monowavelengths.attrs['units'] = 'nm'  # TODO: unit to be verified
-        fluo_monowavelengths.attrs['long name'] = 'fluo_monowavelengths'
+        fluo_monowavelengths_data.attrs['units'] = 'nm'  # TODO: unit to be verified
+        fluo_monowavelengths_data.attrs['long name'] = 'fluo_monowavelengths'
 
-        fluo_spectra = grp_fluo.create_dataset('fluo_spectra',
+        # subgroup for fluo_spectra
+        fluo_spectra=grp_fluo.create_group("fluo_spectra")
+        fluo_spectra.attrs["NX_class"] = 'NXdetector'
+        
+        fluo_spectra_data = fluo_spectra.create_dataset('fluo_spectra',
                                                data=data['Fluo_spectra'],
                                                shape=data['Fluo_spectra'].shape,
                                                dtype=np.float32)
-        fluo_spectra.attrs['long name'] = 'fluo_spectra'
+        fluo_spectra_data.attrs['long name'] = 'fluo_spectra'
+        fluo_spectra_data.attrs['units'] = 'a.u.'
 
-        fluo_wavelength = grp_fluo.create_dataset('fluo_wavelength',
+        # subgroup for fluo_wavelength
+        fluo_wavelength=grp_fluo.create_group("fluo_wavelength")
+        fluo_wavelength.attrs["NX_class"] = 'NXdetector'
+        fluo_wavelength_data= fluo_wavelength.create_dataset('fluo_wavelength',
                                                   data=data['Fluo_wavelength'],
                                                   shape=data[
                                                       'Fluo_wavelength'].shape,
                                                   dtype=np.float32)
-        fluo_wavelength.attrs['units'] = 'nm'  # TODO: unit to be verified
-        fluo_wavelength.attrs['long name'] = 'fluo_wavelength'
+        fluo_wavelength_data.attrs['units'] = 'nm'  # TODO: unit to be verified
+        fluo_wavelength_data.attrs['long name'] = 'fluo_wavelength'
 
         # dummy groups, no information currently available
-        grp_sample_cell = hf.create_group("/entry/sample/sample_cell")
-        grp_sample_cell.attrs["NX_class"] = 'NXenvironment'
-        grp_sample_cell.create_dataset('description', data='NUrF sample cell')
-        grp_sample_cell.create_dataset('type', data='SQ1-ALL')
+        #grp_sample_cell = hf.create_group("/entry/sample/sample_cell")
+        #grp_sample_cell.attrs["NX_class"] = 'NXenvironment'
+        #grp_sample_cell.create_dataset('description', data='NUrF sample cell')
+        #grp_sample_cell.create_dataset('type', data='SQ1-ALL')
 
-        grp_pumps = hf.create_group("/entry/sample/hplc_pump")
-        grp_pumps.attrs["NX_class"] = 'NXenvironment'
-        grp_pumps.create_dataset("description", data='HPLC_pump')
+        #grp_pumps = hf.create_group("/entry/sample/hplc_pump")
+        #grp_pumps.attrs["NX_class"] = 'NXenvironment'
+        #grp_pumps.create_dataset("description", data='HPLC_pump')
 
         #no more valves
         #grp_valves = grp_nurf.create_group("Valves")
         #grp_valves.attrs["NX_class"] = 'NXenvironment'
         #grp_valves.create_dataset("description", data='Valves')
 
-        grp_densito = hf.create_group("/entry/instrument/densitometer")
-        grp_densito.attrs["NX_class"] = 'NXdetector'
-        grp_densito.create_dataset("description", data='Densitometer')
+        #grp_densito = hf.create_group("/entry/instrument/densitometer")
+        #grp_densito.attrs["NX_class"] = 'NXdetector'
+        #grp_densito.create_dataset("description", data='Densitometer')

--- a/examples/loki/nurf_data.py
+++ b/examples/loki/nurf_data.py
@@ -102,25 +102,23 @@ def nurf_file_creator(loki_file, path_to_loki_file, data):
 
     # open the file and append
     with h5py.File(loki_file, 'a') as hf:
-        
-        #print(list(hf['/entry/'].keys()))
                 
         #comment on names
         #UV/FL_Background is the dark
         #UV/FL_Intensity0 is the reference
         #UV/FL_Spectra is the sample
         
-        # image key for the uv_dark
-        # number of frames (nFrames) given indirectly as part of the shape of the arrays 
+        # image_key: number of frames (nFrames) given indirectly as part of the shape of the arrays 
         # TODO: keep in mind what happens if multiple dark or reference frames are taken
         
         #I need to reshape data['UV_spectra']
         data['UV_spectra']=np.reshape(data['UV_spectra'],(np.shape(data['UV_spectra'])[0],np.shape(data['UV_spectra'])[1]))
     
-        # I want it this way 
+        # assemble all spectra in one variable
         uv_all_data=np.column_stack((data['UV_spectra'].T,data['UV_background'], data['UV_intensity0']))
         
-        # assemble image_key #TODO needs later to be verified with real data from hardware
+        # assemble image_key 
+        # #TODO: needs later to be verified with real data from hardware
         uv_nb_spectra=np.shape(data['UV_spectra'])[0]
         uv_ik_spectra=np.zeros((1,uv_nb_spectra))  #interperation here: 0 for sample (in comparison to projections)
       
@@ -201,8 +199,9 @@ def nurf_file_creator(loki_file, path_to_loki_file, data):
             
         fluo_image_key=np.column_stack((fluo_ik_spectra,fluo_ik_dark, fluo_ik_ref))
         
-        # something is not okay with the real Fluo_intensity0 data, it contains only one 0, at least in my file from the ILL beamtime
-        # this code block can later be adjusted
+        # Something is not okay with the real Fluo_intensity0 data from ILL. It contains only one 0, at least in my file from the ILL beamtime. 
+        # Also, some fluo spcetra in between are just dummy ones. There were acquisition problems.
+        # This code block can later be adjusted
         try:
             assert (np.shape(data['Fluo_intensity0'])[0]!=1), 'Fluo_intensity0 contains only one value.'
         except AssertionError as error:
@@ -211,7 +210,6 @@ def nurf_file_creator(loki_file, path_to_loki_file, data):
         # assemble all fluo data    
         fluo_all_data=np.column_stack((data['Fluo_spectra'].T,data['Fluo_background'], data['Fluo_intensity0']))
         
-
         
         # subgroup for fluo all data (sample, dark, reference)
         fluo_signal=grp_fluo.create_group("fluo_all_data")
@@ -226,7 +224,6 @@ def nurf_file_creator(loki_file, path_to_loki_file, data):
         fluo_signal_data.attrs['axes']= [ "wavelength", "." ]   #see example in NXdata, time as x-axis is first entry
         fluo_signal_image_key=fluo_signal.create_dataset('image_key',data=fluo_image_key,shape=fluo_image_key.shape, dtype=np.int32)
        
-
 
         # subgroup for fluo_integration_time
         fluo_inttime_data = grp_fluo.create_dataset('fluo_integration_time',

--- a/examples/loki/nurf_data.py
+++ b/examples/loki/nurf_data.py
@@ -103,75 +103,101 @@ def nurf_file_creator(loki_file, path_to_loki_file, data):
     # open the file and append
     with h5py.File(loki_file, 'a') as hf:
         
-        
         #print(list(hf['/entry/'].keys()))
-        
+                
         # create the various subgrous and their attributes
+        
+        #comment on names
+        #UV/FL_Background is the dark
+        #UV/FL_Intensity0 is the reference
+        #UV/FL_Spectra is the sample
+        
+        # image key for the uv_dark
+        # number of frames (nFrames) given indirectly by second(?) dimension of uv_dark_data, 2 is the value for darks 
+        # TODO: keep in mind what happens if multiple dark frames are taken
+        
+        #print(data.keys())
+        print('shape, UV spectra',np.shape(data['UV_spectra']))
+        print('dim, UV spectra',data['UV_spectra'].ndim)
+        print('shape, UV background', np.shape(data['UV_background']))
+        print('dim, UV background',data['UV_background'].ndim)
+        print('shape, UV reference', np.shape(data['UV_intensity0']))
+        print('dim, UV reference',data['UV_intensity0'].ndim)
+        
+        #I need to reshape data['UV_spectra']
+        print(data['UV_spectra'].ndim)
+        data['UV_spectra']=np.reshape(data['UV_spectra'],(np.shape(data['UV_spectra'])[0],np.shape(data['UV_spectra'])[1]))
+        print(np.shape(data['UV_spectra']), data['UV_spectra'].ndim)
+
+        # other option to stack all data together
+        #all_data1=np.row_stack((data['UV_spectra'],data['UV_background'], data['UV_intensity0']))
+        #print('all_data shape', np.shape(all_data1))
+        #print(all_data1[:,0:4])
+        
+        # but I want it this way 
+        all_data=np.column_stack((data['UV_spectra'].T,data['UV_background'], data['UV_intensity0']))
+        print('all_data shape', np.shape(all_data))
+        print(all_data[0:4,:])
+        
+        # assemble image_key #TODO needs later to be verified with real data from hardware
+        nb_spectra=np.shape(data['UV_spectra'])[0]
+        uv_ik_spectra=np.zeros((1,nb_spectra))  #interperation here: 0 for sample (in comparison to projections)
+      
+        
+        if data['UV_background'].ndim==1:
+            nb_darks=1
+        else: 
+            nb_darks=np.shape(data['UV_background'])[0]  #TODO: needs to be verified with real data from Judith's setup
+   
+        uv_ik_dark=2* np.ones((1,nb_darks)) 
+        #print(ik_dark)
+        
+        if data['UV_intensity0'].ndim==1:
+            nb_ref=1
+        else:
+            nb_ref=np.shape(data['UV_intensity0'])[0]  #TODO: needs to be verified with real data from Judith's setup
+        uv_ik_ref=4*np.ones((1,nb_ref))  #new image key: 4 for reference
+        #print(ik_ref)
+        
+        # assmebling of image_key
+        uv_image_key=np.column_stack((uv_ik_spectra,uv_ik_dark, uv_ik_ref))  #all_data is as well organised in columns
+        
         
         # UV subgroup
         grp_uv = hf.create_group("/entry/instrument/uv")
-        grp_uv.attrs["NX_class"] = 'NXdetector_group'
+        grp_uv.attrs["NX_class"] = 'NXdata'
         
-        # subgroup for uv_spectra
-        uv_spectra=grp_uv.create_group("uv_spectra")
-        uv_spectra.attrs["NX_class"] = 'NXdetector'
-        uv_spectra_data=uv_spectra.create_dataset('data', data=data['UV_spectra'],
+        # subgroup for uv all data (sample, dark, reference)
+        uv_signal=grp_uv.create_group("uv_all_data")
+        uv_signal_data=uv_signal.create_dataset('data', data=all_data,
+                                           shape=all_data.shape)
+        uv_signal_data.attrs['long_name']= 'uv_all_data'
+        uv_signal_data.attrs['units']= ''
+        uv_signal_data.attrs['signal']= 'data'  #indicate that the main signal is data 
+        uv_signal_data.attrs['axes']= [ "wavelength", "." ]   #see example in NXdata, time as x-axis is first entry
+        uv_signal_image_key=uv_signal.create_dataset('image_key',data=uv_image_key,shape=uv_image_key.shape, dtype=np.int32)
+       
+     
+        # uv_wavelength
+        uv_wavelength_data=grp_uv.create_dataset('uv_wavelength', data=data['UV_wavelength'],
+                                              shape=data['UV_wavelength'].shape,
+                                              dtype=np.float32)
+        
+        uv_wavelength_data.attrs['units'] = 'nm'  # TODO: unit to be verified
+        uv_wavelength_data.attrs['long name'] = 'uv_wavelength'
+                
+                
+        # uv_integration_time
+        uv_inttime_data=grp_uv.create_dataset("uv_integration_time",data=data['UV_IntegrationTime'],
                                            shape=data[
-                                               'UV_spectra'].shape,
+                                               'UV_IntegrationTime'].shape, 
                                            dtype=np.int32)
-        uv_spectra_data.attrs['long_name']= 'uv_spectra'
-        uv_spectra_data.attrs['units']= 'a.u.'
-        
-        # define type of detector 
-        string_dt = h5py.special_dtype(vlen=str) # variable-length string 
-        uv_spectra_type=uv_spectra.create_dataset('type', data='ccd', dtype=string_dt)
-        
-
-    
-        # subgroup for uv_integration time
-        uv_inttime=grp_uv.create_group("uv_integration_time")
-        uv_inttime.attrs["NX_class"] = 'NXdetector'
-    
-        uv_inttime_data=uv_inttime.create_dataset('uv_integration_time',
-                                           data=data['UV_IntegrationTime'],
-                                           shape=data[
-                                               'UV_IntegrationTime'].shape,
-                                           dtype=np.int32)
+                   
         uv_inttime_data.attrs['long_name'] = 'uv_integration_time'
         uv_inttime_data.attrs['units'] = 's'  # TODO: unit to be verified
 
-        # subgroup for uv_background
-        uv_bkg=grp_uv.create_group("uv_background")
-        uv_bkg.attrs["NX_class"] = 'NXdetector'
-
-        uv_bkg_data = uv_bkg.create_dataset('data',
-                                       data=data['UV_background'],
-                                       shape=data['UV_background'].shape,
-                                       dtype=np.float32)
-        uv_bkg_data.attrs['long name'] = 'uv_background'
-        uv_bkg_data.attrs['data'] = 'a.u.'
-
-        # subgroup for uv_intensity0
-        uv_int0=grp_uv.create_group("uv_intensity0")
-        uv_int0.attrs["NX_class"] = 'NXdetector'
-        uv_int0_data = uv_int0.create_dataset('data', data=data['UV_intensity0'], 
-                                            shape=data['UV_intensity0'].shape, 
-                                            dtype=np.float32)
-        uv_int0_data.attrs['long name'] = 'uv_intensity0'
-        uv_int0_data.attrs['units'] = 'a.u.'
-
         
-        # subgroup for uv_wavelength
-        uv_wavelength=grp_uv.create_group("uv_wavelength")
-        uv_wavelength.attrs["NX_class"] = 'NXdetector'
         
-        uv_wavelength_data = uv_wavelength.create_dataset('data',
-                                              data=data['UV_wavelength'],
-                                              shape=data['UV_wavelength'].shape,
-                                              dtype=np.float32)
-        uv_wavelength_data.attrs['units'] = 'nm'  # TODO: unit to be verified
-        uv_wavelength_data.attrs['long name'] = 'uv_wavelength'
-
         # Fluorescence subgroup
         grp_fluo = hf.create_group("/entry/instrument/fluorescence")
         grp_fluo.attrs["NX_class"] = 'NXdetector_group'
@@ -224,10 +250,8 @@ def nurf_file_creator(loki_file, path_to_loki_file, data):
 
         # subgroup for fluo_spectra
         fluo_spectra=grp_fluo.create_group("fluo_spectra")
-        fluo_spectra.attrs["NX_class"] = 'NXdetector'
+        fluo_spectra.attrs["NX_class"] = 'NXdata'
         
-        # define type of detector 
-        fluo_spectra_type=fluo_spectra.create_dataset('type', data='ccd', dtype=string_dt)
         
         fluo_spectra_data = fluo_spectra.create_dataset('fluo_spectra',
                                                data=data['Fluo_spectra'],

--- a/examples/loki/nurf_data.py
+++ b/examples/loki/nurf_data.py
@@ -121,26 +121,28 @@ def nurf_file_creator(loki_file, path_to_loki_file, data):
         # assemble image_key 
         # #TODO: needs later to be verified with real data from hardware
         uv_nb_spectra=np.shape(data['UV_spectra'])[0]
-        uv_ik_spectra=np.zeros((1,uv_nb_spectra))  #interperation here: 0 for sample (in comparison to projections)
-      
+    
+        uv_ik_spectra=np.zeros(uv_nb_spectra)  #interperation here: 0 for sample (in comparison to projections)
+
         # find out how many nFrames each item (sample, dark, reference) has
         if data['UV_background'].ndim==1:
             uv_nb_darks=1
         else: 
             uv_nb_darks=np.shape(data['UV_background'])[1]  #TODO: needs to be verified with real data from Judith's setup
    
-        uv_ik_dark=2* np.ones((1,uv_nb_darks)) 
+        uv_ik_dark=2* np.ones((uv_nb_darks)) 
+        #uv_ik_dark=np.full(uv_nb_darks, 2)
         
         if data['UV_intensity0'].ndim==1:
             uv_nb_ref=1
         else:
             uv_nb_ref=np.shape(data['UV_intensity0'])[1]  #TODO: needs to be verified with real data from Judith's setup
-        uv_ik_ref=4*np.ones((1,uv_nb_ref))  #new image key: 4 for reference
-        #print(ik_ref)
+        uv_ik_ref=4*np.ones((uv_nb_ref))  #new image key: 4 for reference
+        #uv_ik_ref=np.full(uv_nb_ref,4)
+    
         
         # assmebling of image_key
-        uv_spectrum_key=np.column_stack((uv_ik_spectra,uv_ik_dark, uv_ik_ref))  #all_data is as well organised in columns
-        
+        uv_spectrum_key=np.hstack((uv_ik_spectra,uv_ik_dark, uv_ik_ref)) 
         
         # UV subgroup
         grp_uv = hf.create_group("/entry/instrument/uv")
@@ -198,21 +200,22 @@ def nurf_file_creator(loki_file, path_to_loki_file, data):
         data['Fluo_spectra']=np.squeeze(data['Fluo_spectra'], axis=2)
         
         fluo_nb_spectra=np.shape(data['Fluo_spectra'])[0]
-        fluo_ik_spectra=np.zeros((1, fluo_nb_spectra))
+        fluo_ik_spectra=np.zeros(fluo_nb_spectra)
         
         if data['Fluo_background'].ndim==1:
             fluo_nb_dark=1
         else:
             fluo_nb_dark=np.shape(data['Fluo_background'])[1] #TODO: needs to be verified with Judith's setup
-        fluo_ik_dark=2*np.ones((1,fluo_nb_dark))
+        fluo_ik_dark=2*np.ones(fluo_nb_dark)
         
         if data['Fluo_intensity0'].ndim==1:
             fluo_nb_ref=1
         else:
             fluo_nb_ref=np.shape(data['Fluo_intensity0'])[1] #TODO: needs to be verified with Judith's setup
-        fluo_ik_ref=4*np.ones((1,fluo_nb_ref))
+        fluo_ik_ref=4*np.ones(fluo_nb_ref)
             
-        fluo_spectrum_key=np.column_stack((fluo_ik_spectra,fluo_ik_dark, fluo_ik_ref))
+        fluo_spectrum_key=np.hstack((fluo_ik_spectra,fluo_ik_dark, fluo_ik_ref))
+        
         
         # Something is not okay with the real Fluo_intensity0 data from ILL. It contains only one 0, at least in my file from the ILL beamtime. 
         # Also, some fluo spcetra in between are just dummy ones. There were acquisition problems.

--- a/examples/loki/nurf_data.py
+++ b/examples/loki/nurf_data.py
@@ -177,6 +177,10 @@ def nurf_file_creator(loki_file, path_to_loki_file, data):
         uv_inttime_data.attrs['long_name'] = 'uv_integration_time'
         uv_inttime_data.attrs['units'] = 'us'  # TODO: unit to be verified, currently in micro-seconds
 
+        # Fluorescence subgroup
+        grp_fluo = hf.create_group("/entry/instrument/fluorescence")
+        grp_fluo.attrs["NX_class"] = 'NXdata'
+        
         # currenty real fluo data is often messed up (i.e. empty spectra inbetween real ones)
         # reshaping
         data['Fluo_spectra']=np.reshape(data['Fluo_spectra'],(np.shape(data['Fluo_spectra'])[0],np.shape(data['Fluo_spectra'])[1]))
@@ -207,10 +211,7 @@ def nurf_file_creator(loki_file, path_to_loki_file, data):
         # assemble all fluo data    
         fluo_all_data=np.column_stack((data['Fluo_spectra'].T,data['Fluo_background'], data['Fluo_intensity0']))
         
-    
-        # Fluorescence subgroup
-        grp_fluo = hf.create_group("/entry/instrument/fluorescence")
-        grp_fluo.attrs["NX_class"] = 'NXdata'
+
         
         # subgroup for fluo all data (sample, dark, reference)
         fluo_signal=grp_fluo.create_group("fluo_all_data")

--- a/examples/loki/nurf_data.py
+++ b/examples/loki/nurf_data.py
@@ -258,7 +258,6 @@ def nurf_file_creator(loki_file, path_to_loki_file, data):
         # maybe it does not matter at what monowavelength dark and reference are measured, but I have to add then dummy values
         # dummy value for monowavelength for dark:  NaN nm
         # dummy value for monowavelength for reference (until I know):  NaN nm
-        #print('This is the start for mwl', data['Fluo_monowavelengths'])
         # again the fluo data can be messed up here, example: 1 monowavelength, but 7 fluo spectra in  103418.nxs
         try:
             assert (np.shape(data['Fluo_monowavelengths'])[0]!=1), 'Fluo_monowavelengths contains only one value.'
@@ -267,24 +266,19 @@ def nurf_file_creator(loki_file, path_to_loki_file, data):
         
         #how many monowavelengths ?  
         nb_monowavelengths=data['Fluo_monowavelengths'].size
-        #print('This is the new monowavelength', data['Fluo_monowavelengths'])
         
         # create a dummy vector for monowavelength 
         dummy_mwl=np.ones(dummy_vec.shape)*(-1)
         # I replace the first entries with the corect Fluo_monowavelengths
         dummy_mwl[0:nb_monowavelengths]=data['Fluo_monowavelengths']
-        #print('This is the dummy vec mwl',dummy_mwl) 
         # now I need to add the monowavelengths for dark and reference, but they are not stored with the ILL data :(
         # I go for NaN
         # add monowavelengths for number of darks
         dummy_mwl[nb_monowavelengths:nb_monowavelengths+fluo_nb_dark]=np.nan
-        #print('This is the dummy vec mwl after dark',dummy_mwl) 
         # add monowavelengths for number of reference
         dummy_mwl[nb_monowavelengths+fluo_nb_dark:nb_monowavelengths+fluo_nb_dark+fluo_nb_ref]=np.nan
-        #print('This is the dummy vec mwl after ref',dummy_mwl) 
         
         data['Fluo_monowavelengths']=dummy_mwl
-        #print('This is the end', data['Fluo_monowavelengths'])
 
         # fluo spectra
         fluo_signal_data = grp_fluo.create_dataset('data',

--- a/examples/loki/nurf_data.py
+++ b/examples/loki/nurf_data.py
@@ -111,11 +111,19 @@ def nurf_file_creator(loki_file, path_to_loki_file, data):
         # image_key: number of frames (nFrames) given indirectly as part of the shape of the arrays 
         # TODO: keep in mind what happens if multiple dark or reference frames are taken
         
+        # remove axis=2 of length one from the array
+        data['UV_spectra']=np.squeeze(data['UV_spectra'], axis=2)  #this removes the third axis in this array, TODO: needs later to be verified with real data from hardware
+        print('shape spectrum', np.shape(data['UV_spectra']))
+        print('shape background', np.shape(data['UV_background']))
+        print('shape intensity0', np.shape(data['UV_intensity0']))
+        
         #I need to reshape data['UV_spectra']
-        data['UV_spectra']=np.reshape(data['UV_spectra'],(np.shape(data['UV_spectra'])[0],np.shape(data['UV_spectra'])[1]))
+        #data['UV_spectra']=np.reshape(data['UV_spectra'],(np.shape(data['UV_spectra'])[0],np.shape(data['UV_spectra'])[1]))
     
         # assemble all spectra in one variable
-        uv_all_data=np.column_stack((data['UV_spectra'].T,data['UV_background'], data['UV_intensity0']))
+        #uv_all_data=np.column_stack((data['UV_spectra'].T,data['UV_background'], data['UV_intensity0']))
+        uv_all_data=np.row_stack((data['UV_spectra'],data['UV_background'], data['UV_intensity0']))
+        print('shape of uv_all_data', np.shape(uv_all_data))
         
         # assemble image_key 
         # #TODO: needs later to be verified with real data from hardware
@@ -140,6 +148,9 @@ def nurf_file_creator(loki_file, path_to_loki_file, data):
         
         # assmebling of image_key
         uv_image_key=np.column_stack((uv_ik_spectra,uv_ik_dark, uv_ik_ref))  #all_data is as well organised in columns
+        
+        
+        
         
         
         # UV subgroup

--- a/examples/loki/nurf_data.py
+++ b/examples/loki/nurf_data.py
@@ -150,16 +150,16 @@ def nurf_file_creator(loki_file, path_to_loki_file, data):
         
         # uv spectra
         uv_signal_data=grp_uv.create_dataset('data', data=uv_all_data, dtype=np.float32)
-        uv_signal_data.attrs['long name']= 'uv_all_data'
+        uv_signal_data.attrs['long name']= 'all_data'
         uv_signal_data.attrs['units']= ''
         grp_uv.attrs['signal']= 'data'  #indicate that the main signal is data 
         grp_uv.attrs['axes']= [ "time", "wavelength" ] #time is here the first axis, i.e axis=0, wavelength is axis=1
         
         # define the AXISNAME_indices
-        grp_uv.attrs['uv_time_indices'] = 0
-        grp_uv.attrs['uv_spectrum_key_indices'] = 0
-        grp_uv.attrs['uv_integration_time_indices'] = 0
-        grp_uv.attrs['uv_wavelength_indices'] = 1
+        grp_uv.attrs['time_indices'] = 0
+        grp_uv.attrs['spectrum_key_indices'] = 0
+        grp_uv.attrs['integration_time_indices'] = 0
+        grp_uv.attrs['wavelength_indices'] = 1
         
         # uv_spectrum_key
         uv_signal_image_key=grp_uv.create_dataset('uv_spectrum_key',data=uv_spectrum_key, dtype=np.int32)

--- a/examples/loki/nurf_data.py
+++ b/examples/loki/nurf_data.py
@@ -163,10 +163,13 @@ def nurf_file_creator(loki_file, path_to_loki_file, data):
                 
                 
         # uv_integration_time
+        grp_uv.attrs['auxiliary_signals'] = ['uv_integration_time']
         uv_inttime_data=grp_uv.create_dataset("uv_integration_time",data=data['UV_IntegrationTime'], dtype=np.int32)
                    
         uv_inttime_data.attrs['long_name'] = 'uv_integration_time'
         uv_inttime_data.attrs['units'] = 'us'  # TODO: unit to be verified, currently in micro-seconds
+
+
 
         # Fluorescence subgroup
         grp_fluo = hf.create_group("/entry/instrument/fluorescence")
@@ -216,6 +219,7 @@ def nurf_file_creator(loki_file, path_to_loki_file, data):
        
 
         # fluo_integration_time
+        grp_fluo.attrs['auxiliary_signals'] = ['fluo_integration_time']
         fluo_inttime_data = grp_fluo.create_dataset('fluo_integration_time',
                                                data=data['Fluo_IntegrationTime'],
                                                dtype=np.float32)

--- a/examples/loki/nurf_data.py
+++ b/examples/loki/nurf_data.py
@@ -122,15 +122,10 @@ def nurf_file_creator(loki_file, path_to_loki_file, data):
         uv_spectra_data.attrs['long_name']= 'uv_spectra'
         uv_spectra_data.attrs['units']= 'a.u.'
         
-        # How to write type from NXdetector? 
-        # type: (optional) NX_CHAR
-        # Description of type such as He3 gas cylinder, He3 PSD, scintillator, fission chamber, proportion counter, ion
-        # chamber, ccd, pixel, image plate, CMOS, ...
-
-        # Like this?
-        string_dt = h5py.special_dtype(vlen=str)
+        # define type of detector 
+        string_dt = h5py.special_dtype(vlen=str) # variable-length string 
         uv_spectra_type=uv_spectra.create_dataset('type', data='ccd', dtype=string_dt)
-        uv_spectra_type.attrs['type']='ccd'
+        
 
     
         # subgroup for uv_integration time
@@ -230,6 +225,9 @@ def nurf_file_creator(loki_file, path_to_loki_file, data):
         # subgroup for fluo_spectra
         fluo_spectra=grp_fluo.create_group("fluo_spectra")
         fluo_spectra.attrs["NX_class"] = 'NXdetector'
+        
+        # define type of detector 
+        fluo_spectra_type=fluo_spectra.create_dataset('type', data='ccd', dtype=string_dt)
         
         fluo_spectra_data = fluo_spectra.create_dataset('fluo_spectra',
                                                data=data['Fluo_spectra'],

--- a/examples/loki/nurf_data.py
+++ b/examples/loki/nurf_data.py
@@ -146,31 +146,24 @@ def nurf_file_creator(loki_file, path_to_loki_file, data):
         grp_uv = hf.create_group("/entry/instrument/uv")
         grp_uv.attrs["NX_class"] = 'NXdata'
         
-        # subgroup for uv all data (sample, dark, reference)
-        uv_signal=grp_uv.create_group("uv_all_data")
-        uv_signal_data=uv_signal.create_dataset('data', data=uv_all_data,
-                                           shape=uv_all_data.shape)
-        uv_signal_data.attrs['long_name']= 'uv_all_data'
+        uv_signal_data=grp_uv.create_dataset('data', data=uv_all_data, dtype=np.float32)
+        uv_signal_data.attrs['long name']= 'uv_all_data'
         uv_signal_data.attrs['units']= ''
-        uv_signal_data.attrs['signal']= 'data'  #indicate that the main signal is data 
-        uv_signal_data.attrs['axes']= [ "wavelength", "." ]   #see example in NXdata, time as x-axis is first entry
-        uv_signal_image_key=uv_signal.create_dataset('image_key',data=uv_image_key,shape=uv_image_key.shape, dtype=np.int32)
+        grp_uv.attrs['signal']= 'data'  #indicate that the main signal is data 
+        grp_uv.attrs['axes']= [ "wavelength", "." ]   #see example in NXdata, time as x-axis is first entry
+       
+        uv_signal_image_key=grp_uv.create_dataset('image_key',data=uv_image_key,shape=uv_image_key.shape, dtype=np.int32)
        
      
         # uv_wavelength
-        uv_wavelength_data=grp_uv.create_dataset('uv_wavelength', data=data['UV_wavelength'],
-                                              shape=data['UV_wavelength'].shape,
-                                              dtype=np.float32)
+        uv_wavelength_data=grp_uv.create_dataset('uv_wavelength', data=data['UV_wavelength'], dtype=np.float32)
         
         uv_wavelength_data.attrs['units'] = 'nm'  # TODO: unit to be verified
         uv_wavelength_data.attrs['long name'] = 'uv_wavelength'
                 
                 
         # uv_integration_time
-        uv_inttime_data=grp_uv.create_dataset("uv_integration_time",data=data['UV_IntegrationTime'],
-                                           shape=data[
-                                               'UV_IntegrationTime'].shape, 
-                                           dtype=np.int32)
+        uv_inttime_data=grp_uv.create_dataset("uv_integration_time",data=data['UV_IntegrationTime'], dtype=np.int32)
                    
         uv_inttime_data.attrs['long_name'] = 'uv_integration_time'
         uv_inttime_data.attrs['units'] = 'us'  # TODO: unit to be verified, currently in micro-seconds
@@ -210,42 +203,36 @@ def nurf_file_creator(loki_file, path_to_loki_file, data):
         # assemble all fluo data    
         fluo_all_data=np.column_stack((data['Fluo_spectra'].T,data['Fluo_background'], data['Fluo_intensity0']))
         
-        
-        # subgroup for fluo all data (sample, dark, reference)
-        fluo_signal=grp_fluo.create_group("fluo_all_data")
-                
-        fluo_signal_data = fluo_signal.create_dataset('data',
-                                               data=fluo_all_data,
-                                               shape=fluo_all_data.shape)
+      
+              
+        fluo_signal_data = grp_fluo.create_dataset('data',
+                                               data=fluo_all_data, dtype=np.float32)
         fluo_signal_data.attrs['long name'] = 'fluo_all_data'
         fluo_signal_data.attrs['units'] = 'a.u.'
 
-        fluo_signal_data.attrs['signal']= 'data'  #indicate that the main signal is data 
-        fluo_signal_data.attrs['axes']= [ "wavelength", "." ]   #see example in NXdata, time as x-axis is first entry
-        fluo_signal_image_key=fluo_signal.create_dataset('image_key',data=fluo_image_key,shape=fluo_image_key.shape, dtype=np.int32)
+        grp_fluo.attrs['signal']= 'data'  #indicate that the main signal is data 
+        grp_fluo.attrs['axes']= [ "wavelength", "." ]   #see example in NXdata, time as x-axis is first entry
+        fluo_signal_image_key=grp_fluo.create_dataset('image_key',data=fluo_image_key,shape=fluo_image_key.shape, dtype=np.int32)
        
 
-        # subgroup for fluo_integration_time
+        # fluo_integration_time
         fluo_inttime_data = grp_fluo.create_dataset('fluo_integration_time',
                                                data=data['Fluo_IntegrationTime'],
-                                               shape=data['Fluo_IntegrationTime'].shape,
-                                               dtype=np.int32)
+                                               dtype=np.float32)
         fluo_inttime_data.attrs['units'] = 'us'  # TODO: unit to be verified, currently micro-seconds
         fluo_inttime_data.attrs['long name'] = 'fluo_integration_time'
 
 
-        # subgroup for fluo_monowavelengths
+        # fluo_monowavelengths
         fluo_monowavelengths_data = grp_fluo.create_dataset('fluo_monowavelengths',
                                                        data=data[
                                                            'Fluo_monowavelengths'],
-                                                       shape=data[
-                                                           'Fluo_monowavelengths'].shape,
                                                        dtype=np.float32)
         fluo_monowavelengths_data.attrs['units'] = 'nm'  # TODO: unit to be verified
         fluo_monowavelengths_data.attrs['long name'] = 'fluo_monowavelengths'
 
         
-        # subgroup for fluo_wavelength
+        # fluo_wavelength
         fluo_wavelength_data= grp_fluo.create_dataset('fluo_wavelength',
                                                   data=data['Fluo_wavelength'],
                                                   shape=data[

--- a/examples/loki/nurf_data.py
+++ b/examples/loki/nurf_data.py
@@ -153,7 +153,7 @@ def nurf_file_creator(loki_file, path_to_loki_file, data):
         uv_signal_data.attrs['long name']= 'all_data'
         uv_signal_data.attrs['units']= 'counts'
         grp_uv.attrs['signal']= 'data'  #indicate that the main signal is data 
-        grp_uv.attrs['axes']= [ "time", "wavelength" ] #time is here the first axis, i.e axis=0, wavelength is axis=1
+        grp_uv.attrs['axes']= [ "spectrum", "wavelength" ] #time is here the first axis, i.e axis=0, wavelength is axis=1
         
         # define the AXISNAME_indices
         grp_uv.attrs['time_indices'] = 0
@@ -241,7 +241,7 @@ def nurf_file_creator(loki_file, path_to_loki_file, data):
     
 
         grp_fluo.attrs['signal']= 'data'  #indicate that the main signal is data 
-        grp_fluo.attrs['axes']= [ "time", "wavelength"]
+        grp_fluo.attrs['axes']= [ "spectrum",  "wavelength"]
         
         # define the AXISNAME_indices
         grp_fluo.attrs['time_indices'] = 0

--- a/examples/loki/nurf_data.py
+++ b/examples/loki/nurf_data.py
@@ -185,8 +185,12 @@ def nurf_file_creator(loki_file, path_to_loki_file, data):
         uv_wavelength_data.attrs['long name'] = 'uv_wavelength'
                 
                 
-        # uv_integration_time
-        uv_inttime_data=grp_uv.create_dataset("uv_integration_time",data=data['UV_IntegrationTime'], dtype=np.int32)
+        # creating for each spectrum, even dark and background, the integration time
+        # TODO: needs to be verified with real hardware
+        uv_inttime=np.full(np.shape(uv_spectrum_key),data['UV_IntegrationTime'])
+        
+         # uv_integration_time
+        uv_inttime_data=grp_uv.create_dataset("uv_integration_time",data=uv_inttime, dtype=np.int32)
                    
         uv_inttime_data.attrs['long_name'] = 'uv_integration_time'
         uv_inttime_data.attrs['units'] = 'us'  # TODO: unit to be verified, currently in micro-seconds
@@ -261,9 +265,13 @@ def nurf_file_creator(loki_file, path_to_loki_file, data):
         # TODO: Do we need here an attribute for the unit?
        
        
+        # creating integration time for each fluo spectrum including dark and reference
+        # TODO: needs to be verfied with hardware
+        fluo_inttime=np.full(np.shape(fluo_spectrum_key),data['Fluo_IntegrationTime'])
+       
         # fluo_integration_time
         fluo_inttime_data = grp_fluo.create_dataset('fluo_integration_time',
-                                               data=data['Fluo_IntegrationTime'],
+                                               data=fluo_inttime,
                                                dtype=np.float32)
         fluo_inttime_data.attrs['units'] = 'us'  # TODO: unit to be verified, currently micro-seconds
         fluo_inttime_data.attrs['long name'] = 'fluo_integration_time'
@@ -281,13 +289,9 @@ def nurf_file_creator(loki_file, path_to_loki_file, data):
         # fluo_wavelength
         fluo_wavelength_data= grp_fluo.create_dataset('fluo_wavelength',
                                                   data=data['Fluo_wavelength'],
-                                                  shape=data[
-                                                      'Fluo_wavelength'].shape,
                                                   dtype=np.float32)
         fluo_wavelength_data.attrs['units'] = 'nm'  # TODO: unit to be verified
         fluo_wavelength_data.attrs['long name'] = 'fluo_wavelength'
-
-
 
         # dummy groups, no information currently available
         #grp_sample_cell = hf.create_group("/entry/sample/sample_cell")

--- a/examples/loki/nurf_data.py
+++ b/examples/loki/nurf_data.py
@@ -169,7 +169,6 @@ def nurf_file_creator(loki_file, path_to_loki_file, data):
         
         # define the AXISNAME_indices
         grp_uv.attrs['time_indices'] = 0
-        grp_uv.attrs['spectrum_key_indices'] = 0
         grp_uv.attrs['integration_time_indices'] = 0
         grp_uv.attrs['wavelength_indices'] = 1
 

--- a/examples/loki/nurf_data.py
+++ b/examples/loki/nurf_data.py
@@ -162,7 +162,7 @@ def nurf_file_creator(loki_file, path_to_loki_file, data):
         grp_uv.attrs['wavelength_indices'] = 1
         
         # uv_spectrum_key
-        uv_signal_image_key=grp_uv.create_dataset('uv_spectrum_key',data=uv_spectrum_key, dtype=np.int32)
+        uv_signal_image_key=grp_uv.create_dataset('spectrum_key',data=uv_spectrum_key, dtype=np.int32)
         
         # uv_time
         # dummy timestamps for uv_time
@@ -173,16 +173,16 @@ def nurf_file_creator(loki_file, path_to_loki_file, data):
     
         # see https://stackoverflow.com/questions/23570632/store-datetimes-in-hdf5-with-h5py 
         # suggested work around because h5py does not support time types
-        uv_time_data=grp_uv.create_dataset('uv_time', data=uv_time.view('<i8'), dtype='<i8')
+        uv_time_data=grp_uv.create_dataset('time', data=uv_time.view('<i8'), dtype='<i8')
         # to read
         #print(uv_time_data[:].view('<M8[us]'))
         # TODO: Do we need here an attribute for the unit?
        
         # uv_wavelength
-        uv_wavelength_data=grp_uv.create_dataset('uv_wavelength', data=data['UV_wavelength'], dtype=np.float32)
+        uv_wavelength_data=grp_uv.create_dataset('wavelength', data=data['UV_wavelength'], dtype=np.float32)
         
         uv_wavelength_data.attrs['units'] = 'nm'  # TODO: unit to be verified
-        uv_wavelength_data.attrs['long name'] = 'uv_wavelength'
+        uv_wavelength_data.attrs['long name'] = 'wavelength'
                 
                 
         # creating for each spectrum, even dark and background, the integration time
@@ -190,9 +190,9 @@ def nurf_file_creator(loki_file, path_to_loki_file, data):
         uv_inttime=np.full(np.shape(uv_spectrum_key),data['UV_IntegrationTime'])
         
          # uv_integration_time
-        uv_inttime_data=grp_uv.create_dataset("uv_integration_time",data=uv_inttime, dtype=np.int32)
+        uv_inttime_data=grp_uv.create_dataset("integration_time",data=uv_inttime, dtype=np.int32)
                    
-        uv_inttime_data.attrs['long_name'] = 'uv_integration_time'
+        uv_inttime_data.attrs['long_name'] = 'integration_time'
         uv_inttime_data.attrs['units'] = 'us'  # TODO: unit to be verified, currently in micro-seconds
 
         # Fluorescence subgroup

--- a/examples/loki/nurf_data.py
+++ b/examples/loki/nurf_data.py
@@ -151,7 +151,7 @@ def nurf_file_creator(loki_file, path_to_loki_file, data):
         # uv spectra
         uv_signal_data=grp_uv.create_dataset('data', data=uv_all_data, dtype=np.float32)
         uv_signal_data.attrs['long name']= 'all_data'
-        uv_signal_data.attrs['units']= ''
+        uv_signal_data.attrs['units']= 'counts'
         grp_uv.attrs['signal']= 'data'  #indicate that the main signal is data 
         grp_uv.attrs['axes']= [ "time", "wavelength" ] #time is here the first axis, i.e axis=0, wavelength is axis=1
         
@@ -174,6 +174,7 @@ def nurf_file_creator(loki_file, path_to_loki_file, data):
         # see https://stackoverflow.com/questions/23570632/store-datetimes-in-hdf5-with-h5py 
         # suggested work around because h5py does not support time types
         uv_time_data=grp_uv.create_dataset('time', data=uv_time.view('<i8'), dtype='<i8')
+        uv_time_data.attrs['unit'] = 'us'
         # to read
         #print(uv_time_data[:].view('<M8[us]'))
         # TODO: Do we need here an attribute for the unit?
@@ -236,7 +237,7 @@ def nurf_file_creator(loki_file, path_to_loki_file, data):
         fluo_signal_data = grp_fluo.create_dataset('data',
                                                data=fluo_all_data, dtype=np.float32)
         fluo_signal_data.attrs['long name'] = 'all_data'
-        fluo_signal_data.attrs['units'] = 'a.u.'
+        fluo_signal_data.attrs['units'] = 'counts'
     
 
         grp_fluo.attrs['signal']= 'data'  #indicate that the main signal is data 
@@ -260,6 +261,7 @@ def nurf_file_creator(loki_file, path_to_loki_file, data):
         # see https://stackoverflow.com/questions/23570632/store-datetimes-in-hdf5-with-h5py 
         # suggested work around because h5py does not support time types
         fluo_time_data=grp_fluo.create_dataset('time', data=fluo_time.view('<i8'), dtype='<i8')
+        fluo_time_data.attrs['unit'] = 'us'
         # to read
         #print(fluo_time_data[:].view('<M8[us]'))
         # TODO: Do we need here an attribute for the unit?

--- a/examples/loki/nurf_data.py
+++ b/examples/loki/nurf_data.py
@@ -111,19 +111,12 @@ def nurf_file_creator(loki_file, path_to_loki_file, data):
         # image_key: number of frames (nFrames) given indirectly as part of the shape of the arrays 
         # TODO: keep in mind what happens if multiple dark or reference frames are taken
         
-        # remove axis=2 of length one from the array
+        # remove axis=2 of length one from this array
         data['UV_spectra']=np.squeeze(data['UV_spectra'], axis=2)  #this removes the third axis in this array, TODO: needs later to be verified with real data from hardware
-        print('shape spectrum', np.shape(data['UV_spectra']))
-        print('shape background', np.shape(data['UV_background']))
-        print('shape intensity0', np.shape(data['UV_intensity0']))
         
-        #I need to reshape data['UV_spectra']
-        #data['UV_spectra']=np.reshape(data['UV_spectra'],(np.shape(data['UV_spectra'])[0],np.shape(data['UV_spectra'])[1]))
-    
         # assemble all spectra in one variable
-        #uv_all_data=np.column_stack((data['UV_spectra'].T,data['UV_background'], data['UV_intensity0']))
         uv_all_data=np.row_stack((data['UV_spectra'],data['UV_background'], data['UV_intensity0']))
-        print('shape of uv_all_data', np.shape(uv_all_data))
+      
         
         # assemble image_key 
         # #TODO: needs later to be verified with real data from hardware
@@ -187,8 +180,9 @@ def nurf_file_creator(loki_file, path_to_loki_file, data):
         grp_fluo.attrs["NX_class"] = 'NXdata'
         
         # currenty real fluo data is often messed up (i.e. empty spectra inbetween real ones)
-        # reshaping
-        data['Fluo_spectra']=np.reshape(data['Fluo_spectra'],(np.shape(data['Fluo_spectra'])[0],np.shape(data['Fluo_spectra'])[1]))
+        # remove third axis of length one
+        data['Fluo_spectra']=np.squeeze(data['Fluo_spectra'], axis=2)
+        
         fluo_nb_spectra=np.shape(data['Fluo_spectra'])[0]
         fluo_ik_spectra=np.zeros((1, fluo_nb_spectra))
         
@@ -215,10 +209,9 @@ def nurf_file_creator(loki_file, path_to_loki_file, data):
             data['Fluo_intensity0']=data['Fluo_intensity0'][0]*np.ones((np.shape(data['Fluo_background'])[0]))
            
         # assemble all fluo data    
-        fluo_all_data=np.column_stack((data['Fluo_spectra'].T,data['Fluo_background'], data['Fluo_intensity0']))
-        
-      
-              
+        #fluo_all_data=np.column_stack((data['Fluo_spectra'].T,data['Fluo_background'], data['Fluo_intensity0']))
+        fluo_all_data=np.row_stack((data['Fluo_spectra'],data['Fluo_background'], data['Fluo_intensity0']))
+           
         fluo_signal_data = grp_fluo.create_dataset('data',
                                                data=fluo_all_data, dtype=np.float32)
         fluo_signal_data.attrs['long name'] = 'fluo_all_data'

--- a/examples/loki/nurf_data.py
+++ b/examples/loki/nurf_data.py
@@ -105,49 +105,30 @@ def nurf_file_creator(loki_file, path_to_loki_file, data):
         
         #print(list(hf['/entry/'].keys()))
                 
-        # create the various subgrous and their attributes
-        
         #comment on names
         #UV/FL_Background is the dark
         #UV/FL_Intensity0 is the reference
         #UV/FL_Spectra is the sample
         
         # image key for the uv_dark
-        # number of frames (nFrames) given indirectly by second(?) dimension of uv_dark_data, 2 is the value for darks 
-        # TODO: keep in mind what happens if multiple dark frames are taken
-        
-        #print(data.keys())
-        print('shape, UV spectra',np.shape(data['UV_spectra']))
-        print('dim, UV spectra',data['UV_spectra'].ndim)
-        print('shape, UV background', np.shape(data['UV_background']))
-        print('dim, UV background',data['UV_background'].ndim)
-        print('shape, UV reference', np.shape(data['UV_intensity0']))
-        print('dim, UV reference',data['UV_intensity0'].ndim)
+        # number of frames (nFrames) given indirectly as part of the shape of the arrays 
+        # TODO: keep in mind what happens if multiple dark or reference frames are taken
         
         #I need to reshape data['UV_spectra']
-        print(data['UV_spectra'].ndim)
         data['UV_spectra']=np.reshape(data['UV_spectra'],(np.shape(data['UV_spectra'])[0],np.shape(data['UV_spectra'])[1]))
-        print(np.shape(data['UV_spectra']), data['UV_spectra'].ndim)
-
-        # other option to stack all data together
-        #all_data1=np.row_stack((data['UV_spectra'],data['UV_background'], data['UV_intensity0']))
-        #print('all_data shape', np.shape(all_data1))
-        #print(all_data1[:,0:4])
-        
-        # but I want it this way 
-        all_data=np.column_stack((data['UV_spectra'].T,data['UV_background'], data['UV_intensity0']))
-        print('all_data shape', np.shape(all_data))
-        print(all_data[0:4,:])
-        
+    
+        # I want it this way 
+        uv_all_data=np.column_stack((data['UV_spectra'].T,data['UV_background'], data['UV_intensity0']))
+       
         # assemble image_key #TODO needs later to be verified with real data from hardware
         nb_spectra=np.shape(data['UV_spectra'])[0]
         uv_ik_spectra=np.zeros((1,nb_spectra))  #interperation here: 0 for sample (in comparison to projections)
       
-        
+        # find out how many nFrames each item (sample, dark, reference) has
         if data['UV_background'].ndim==1:
             nb_darks=1
         else: 
-            nb_darks=np.shape(data['UV_background'])[0]  #TODO: needs to be verified with real data from Judith's setup
+            nb_darks=np.shape(data['UV_background'])[1]  #TODO: needs to be verified with real data from Judith's setup
    
         uv_ik_dark=2* np.ones((1,nb_darks)) 
         #print(ik_dark)
@@ -155,7 +136,7 @@ def nurf_file_creator(loki_file, path_to_loki_file, data):
         if data['UV_intensity0'].ndim==1:
             nb_ref=1
         else:
-            nb_ref=np.shape(data['UV_intensity0'])[0]  #TODO: needs to be verified with real data from Judith's setup
+            nb_ref=np.shape(data['UV_intensity0'])[1]  #TODO: needs to be verified with real data from Judith's setup
         uv_ik_ref=4*np.ones((1,nb_ref))  #new image key: 4 for reference
         #print(ik_ref)
         
@@ -169,8 +150,8 @@ def nurf_file_creator(loki_file, path_to_loki_file, data):
         
         # subgroup for uv all data (sample, dark, reference)
         uv_signal=grp_uv.create_group("uv_all_data")
-        uv_signal_data=uv_signal.create_dataset('data', data=all_data,
-                                           shape=all_data.shape)
+        uv_signal_data=uv_signal.create_dataset('data', data=uv_all_data,
+                                           shape=uv_all_data.shape)
         uv_signal_data.attrs['long_name']= 'uv_all_data'
         uv_signal_data.attrs['units']= ''
         uv_signal_data.attrs['signal']= 'data'  #indicate that the main signal is data 

--- a/examples/loki/nurf_data.py
+++ b/examples/loki/nurf_data.py
@@ -258,7 +258,7 @@ def nurf_file_creator(loki_file, path_to_loki_file, data):
         # maybe it does not matter at what monowavelength dark and reference are measured, but I have to add then dummy values
         # dummy value for monowavelength for dark:  NaN nm
         # dummy value for monowavelength for reference (until I know):  NaN nm
-        print('This is the start for mwl', data['Fluo_monowavelengths'])
+        #print('This is the start for mwl', data['Fluo_monowavelengths'])
         # again the fluo data can be messed up here, example: 1 monowavelength, but 7 fluo spectra in  103418.nxs
         try:
             assert (np.shape(data['Fluo_monowavelengths'])[0]!=1), 'Fluo_monowavelengths contains only one value.'
@@ -267,24 +267,24 @@ def nurf_file_creator(loki_file, path_to_loki_file, data):
         
         #how many monowavelengths ?  
         nb_monowavelengths=data['Fluo_monowavelengths'].size
-        print('This is the new monowavelength', data['Fluo_monowavelengths'])
+        #print('This is the new monowavelength', data['Fluo_monowavelengths'])
         
         # create a dummy vector for monowavelength 
         dummy_mwl=np.ones(dummy_vec.shape)*(-1)
         # I replace the first entries with the corect Fluo_monowavelengths
         dummy_mwl[0:nb_monowavelengths]=data['Fluo_monowavelengths']
-        print('This is the dummy vec mwl',dummy_mwl) 
+        #print('This is the dummy vec mwl',dummy_mwl) 
         # now I need to add the monowavelengths for dark and reference, but they are not stored with the ILL data :(
         # I go for NaN
         # add monowavelengths for number of darks
         dummy_mwl[nb_monowavelengths:nb_monowavelengths+fluo_nb_dark]=np.nan
-        print('This is the dummy vec mwl after dark',dummy_mwl) 
+        #print('This is the dummy vec mwl after dark',dummy_mwl) 
         # add monowavelengths for number of reference
         dummy_mwl[nb_monowavelengths+fluo_nb_dark:nb_monowavelengths+fluo_nb_dark+fluo_nb_ref]=np.nan
-        print('This is the dummy vec mwl after ref',dummy_mwl) 
+        #print('This is the dummy vec mwl after ref',dummy_mwl) 
         
         data['Fluo_monowavelengths']=dummy_mwl
-        print('This is the end', data['Fluo_monowavelengths'])
+        #print('This is the end', data['Fluo_monowavelengths'])
 
         # fluo spectra
         fluo_signal_data = grp_fluo.create_dataset('data',

--- a/examples/loki/nurf_data.py
+++ b/examples/loki/nurf_data.py
@@ -155,31 +155,6 @@ def nurf_file_creator(loki_file, path_to_loki_file, data):
         uv_ref_mask[uv_nb_spectra+uv_nb_darks:uv_nb_spectra+uv_nb_darks+uv_nb_ref]=True
 
         
-        # assemble image_key 
-        # #TODO: needs later to be verified with real data from hardware
-        uv_nb_spectra=np.shape(data['UV_spectra'])[0]
-    
-        uv_ik_spectra=np.zeros(uv_nb_spectra)  #interperation here: 0 for sample (in comparison to projections)
-
-        # find out how many nFrames each item (sample, dark, reference) has
-        if data['UV_background'].ndim==1:
-            uv_nb_darks=1
-        else: 
-            uv_nb_darks=np.shape(data['UV_background'])[1]  #TODO: needs to be verified with real data from Judith's setup
-   
-        uv_ik_dark=2* np.ones((uv_nb_darks)) 
-        #uv_ik_dark=np.full(uv_nb_darks, 2)
-        
-        if data['UV_intensity0'].ndim==1:
-            uv_nb_ref=1
-        else:
-            uv_nb_ref=np.shape(data['UV_intensity0'])[1]  #TODO: needs to be verified with real data from Judith's setup
-        uv_ik_ref=4*np.ones((uv_nb_ref))  #new image key: 4 for reference
-        #uv_ik_ref=np.full(uv_nb_ref,4)
-    
-        
-        # assmebling of image_key
-        uv_spectrum_key=np.hstack((uv_ik_spectra,uv_ik_dark, uv_ik_ref)) 
         
         # UV subgroup
         grp_uv = hf.create_group("/entry/instrument/uv")

--- a/scipp_playground.ipynb
+++ b/scipp_playground.ipynb
@@ -1,0 +1,147 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "SyntaxError",
+     "evalue": "invalid syntax (869339054.py, line 4)",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;36m  File \u001b[0;32m\"/var/folders/zs/1bljp9y15h9bxppw44pk88gh0000gn/T/ipykernel_77898/869339054.py\"\u001b[0;36m, line \u001b[0;32m4\u001b[0m\n\u001b[0;31m    print('This is scippneutron 'sn.__version__)\u001b[0m\n\u001b[0m                                 ^\u001b[0m\n\u001b[0;31mSyntaxError\u001b[0m\u001b[0;31m:\u001b[0m invalid syntax\n"
+     ]
+    }
+   ],
+   "source": [
+    "import scippneutron as sn\n",
+    "from scippneutron import nexus\n",
+    "\n",
+    "print('This is scippneutron ',sn.__version__)\n",
+    "\n",
+    "\n",
+    "import numpy as np\n",
+    "import os\n",
+    "import matplotlib"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/Users/gudlo523/Library/CloudStorage/OneDrive-LundUniversity/UU/ESS-NeXus/generate-nexus-files\n",
+      "103418.nxs             larmor.nxs             scipp_playground.ipynb\n",
+      "README.md              \u001b[31mloki.nxs\u001b[m\u001b[m               \u001b[34msrc\u001b[m\u001b[m\n",
+      "\u001b[34mexamples\u001b[m\u001b[m               requirements.txt\n"
+     ]
+    }
+   ],
+   "source": [
+    "!pwd\n",
+    "!ls\n",
+    "test_file='loki.nxs'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with nexus.File(test_file) as f:\n",
+    "    uv=f['entry/instrument/uv'][()]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "NotFoundError",
+     "evalue": "plot.aspect not found",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mNotFoundError\u001b[0m                             Traceback (most recent call last)",
+      "\u001b[0;32m/opt/anaconda3/envs/scippneutron/lib/python3.8/site-packages/IPython/core/formatters.py\u001b[0m in \u001b[0;36m__call__\u001b[0;34m(self, obj)\u001b[0m\n\u001b[1;32m    343\u001b[0m             \u001b[0mmethod\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mget_real_method\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mobj\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mprint_method\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    344\u001b[0m             \u001b[0;32mif\u001b[0m \u001b[0mmethod\u001b[0m \u001b[0;32mis\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 345\u001b[0;31m                 \u001b[0;32mreturn\u001b[0m \u001b[0mmethod\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    346\u001b[0m             \u001b[0;32mreturn\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    347\u001b[0m         \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/opt/anaconda3/envs/scippneutron/lib/python3.8/site-packages/scipp/html/__init__.py\u001b[0m in \u001b[0;36mmake_html\u001b[0;34m(container)\u001b[0m\n\u001b[1;32m     15\u001b[0m         \u001b[0;32mreturn\u001b[0m \u001b[0mvariable_repr\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mcontainer\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     16\u001b[0m     \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 17\u001b[0;31m         \u001b[0;32mreturn\u001b[0m \u001b[0mdataset_repr\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mcontainer\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     18\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     19\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/opt/anaconda3/envs/scippneutron/lib/python3.8/site-packages/scipp/html/formatting_html.py\u001b[0m in \u001b[0;36mdataset_repr\u001b[0;34m(ds)\u001b[0m\n\u001b[1;32m    481\u001b[0m             \u001b[0msections\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mappend\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mattr_section\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mds\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mattrs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mds\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    482\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 483\u001b[0;31m     \u001b[0;32mreturn\u001b[0m \u001b[0m_obj_repr\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mheader_components\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0msections\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    484\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    485\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/opt/anaconda3/envs/scippneutron/lib/python3.8/site-packages/scipp/html/formatting_html.py\u001b[0m in \u001b[0;36m_obj_repr\u001b[0;34m(header_components, sections)\u001b[0m\n\u001b[1;32m    442\u001b[0m     \u001b[0msections\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m\"\"\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mjoin\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34mf\"<li class='sc-section-item'>{s}</li>\"\u001b[0m \u001b[0;32mfor\u001b[0m \u001b[0ms\u001b[0m \u001b[0;32min\u001b[0m \u001b[0msections\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    443\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 444\u001b[0;31m     return (\"<div>\"\n\u001b[0m\u001b[1;32m    445\u001b[0m             \u001b[0;34mf\"{load_icons()}\"\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    446\u001b[0m             \u001b[0;34mf\"{load_style()}\"\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/opt/anaconda3/envs/scippneutron/lib/python3.8/site-packages/scipp/html/resources.py\u001b[0m in \u001b[0;36mload_style\u001b[0;34m()\u001b[0m\n\u001b[1;32m     44\u001b[0m     \u001b[0mLoad\u001b[0m \u001b[0mthe\u001b[0m \u001b[0mbundled\u001b[0m \u001b[0mCSS\u001b[0m \u001b[0mstyle\u001b[0m \u001b[0;32mand\u001b[0m \u001b[0;32mreturn\u001b[0m \u001b[0mit\u001b[0m \u001b[0mwithin\u001b[0m \u001b[0;34m<\u001b[0m\u001b[0mstyle\u001b[0m\u001b[0;34m>\u001b[0m \u001b[0mtags\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     45\u001b[0m     \"\"\"\n\u001b[0;32m---> 46\u001b[0;31m     \u001b[0;32mreturn\u001b[0m \u001b[0;34m'<style id=\"scipp-style-sheet\">'\u001b[0m \u001b[0;34m+\u001b[0m \u001b[0mload_style_sheet\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;34m+\u001b[0m \u001b[0;34m'</style>'\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     47\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     48\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/opt/anaconda3/envs/scippneutron/lib/python3.8/site-packages/scipp/html/resources.py\u001b[0m in \u001b[0;36mload_style_sheet\u001b[0;34m()\u001b[0m\n\u001b[1;32m     36\u001b[0m     \u001b[0mThe\u001b[0m \u001b[0mstring\u001b[0m \u001b[0;32mis\u001b[0m \u001b[0mcached\u001b[0m \u001b[0mupon\u001b[0m \u001b[0mfirst\u001b[0m \u001b[0mcall\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     37\u001b[0m     \"\"\"\n\u001b[0;32m---> 38\u001b[0;31m     return _preprocess_style(pkg_resources.read_text('scipp.html',\n\u001b[0m\u001b[1;32m     39\u001b[0m                                                      'style.css.template'))\n\u001b[1;32m     40\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/opt/anaconda3/envs/scippneutron/lib/python3.8/site-packages/scipp/html/resources.py\u001b[0m in \u001b[0;36m_preprocess_style\u001b[0;34m(template)\u001b[0m\n\u001b[1;32m     19\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     20\u001b[0m \u001b[0;32mdef\u001b[0m \u001b[0m_preprocess_style\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mtemplate\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mstr\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;34m->\u001b[0m \u001b[0mstr\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 21\u001b[0;31m     \u001b[0mcss\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0m_format_style\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mtemplate\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     22\u001b[0m     \u001b[0;32mimport\u001b[0m \u001b[0mre\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     23\u001b[0m     \u001b[0;31m# line breaks are not needed\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/opt/anaconda3/envs/scippneutron/lib/python3.8/site-packages/scipp/html/resources.py\u001b[0m in \u001b[0;36m_format_style\u001b[0;34m(template)\u001b[0m\n\u001b[1;32m     15\u001b[0m     return Template(template).substitute(\n\u001b[1;32m     16\u001b[0m         **{f'{key}_color': val\n\u001b[0;32m---> 17\u001b[0;31m            for key, val in config['colors'].items()})\n\u001b[0m\u001b[1;32m     18\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     19\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/opt/anaconda3/envs/scippneutron/lib/python3.8/site-packages/scipp/configuration/__init__.py\u001b[0m in \u001b[0;36m__getitem__\u001b[0;34m(self, name)\u001b[0m\n\u001b[1;32m     91\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0m__getitem__\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mname\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mstr\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     92\u001b[0m         \u001b[0;34m\"\"\"Return parameter of given name.\"\"\"\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 93\u001b[0;31m         \u001b[0;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mget\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mname\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     94\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     95\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0m__setitem__\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mname\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mstr\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mvalue\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/opt/anaconda3/envs/scippneutron/lib/python3.8/site-packages/scipp/configuration/__init__.py\u001b[0m in \u001b[0;36mget\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m     87\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0mget\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;34m->\u001b[0m \u001b[0mdict\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     88\u001b[0m         \u001b[0;34m\"\"\"Return parameters as a dict.\"\"\"\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 89\u001b[0;31m         \u001b[0;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_cfg\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mget\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_TEMPLATE\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     90\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     91\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0m__getitem__\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mname\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mstr\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/opt/anaconda3/envs/scippneutron/lib/python3.8/site-packages/confuse/core.py\u001b[0m in \u001b[0;36mget\u001b[0;34m(self, template)\u001b[0m\n\u001b[1;32m    306\u001b[0m         \u001b[0mdoesn\u001b[0m\u001b[0;31m'\u001b[0m\u001b[0mt\u001b[0m \u001b[0msatisfy\u001b[0m \u001b[0mthe\u001b[0m \u001b[0mtemplate\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    307\u001b[0m         \"\"\"\n\u001b[0;32m--> 308\u001b[0;31m         \u001b[0;32mreturn\u001b[0m \u001b[0mtemplates\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mas_template\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mtemplate\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mvalue\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mtemplate\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    309\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    310\u001b[0m     \u001b[0;31m# Shortcuts for common templates.\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/opt/anaconda3/envs/scippneutron/lib/python3.8/site-packages/confuse/templates.py\u001b[0m in \u001b[0;36mvalue\u001b[0;34m(self, view, template)\u001b[0m\n\u001b[1;32m    161\u001b[0m         \u001b[0mout\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mAttrDict\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    162\u001b[0m         \u001b[0;32mfor\u001b[0m \u001b[0mkey\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mtyp\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0msubtemplates\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mitems\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 163\u001b[0;31m             \u001b[0mout\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mkey\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mtyp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mvalue\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mview\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mkey\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    164\u001b[0m         \u001b[0;32mreturn\u001b[0m \u001b[0mout\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    165\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/opt/anaconda3/envs/scippneutron/lib/python3.8/site-packages/confuse/templates.py\u001b[0m in \u001b[0;36mvalue\u001b[0;34m(self, view, template)\u001b[0m\n\u001b[1;32m    161\u001b[0m         \u001b[0mout\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mAttrDict\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    162\u001b[0m         \u001b[0;32mfor\u001b[0m \u001b[0mkey\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mtyp\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0msubtemplates\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mitems\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 163\u001b[0;31m             \u001b[0mout\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mkey\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mtyp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mvalue\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mview\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mkey\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    164\u001b[0m         \u001b[0;32mreturn\u001b[0m \u001b[0mout\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    165\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/opt/anaconda3/envs/scippneutron/lib/python3.8/site-packages/confuse/templates.py\u001b[0m in \u001b[0;36mvalue\u001b[0;34m(self, view, template)\u001b[0m\n\u001b[1;32m    328\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0mvalue\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mview\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mtemplate\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    329\u001b[0m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mtemplate\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mtemplate\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 330\u001b[0;31m         \u001b[0;32mreturn\u001b[0m \u001b[0msuper\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mOneOf\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mvalue\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mview\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mtemplate\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    331\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    332\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0mconvert\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mvalue\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mview\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/opt/anaconda3/envs/scippneutron/lib/python3.8/site-packages/confuse/templates.py\u001b[0m in \u001b[0;36mvalue\u001b[0;34m(self, view, template)\u001b[0m\n\u001b[1;32m     68\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     69\u001b[0m         \u001b[0;31m# Get default value, or raise if required.\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 70\u001b[0;31m         \u001b[0;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mget_default_value\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mview\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mname\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     71\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     72\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0mget_default_value\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mkey_name\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'default'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/opt/anaconda3/envs/scippneutron/lib/python3.8/site-packages/confuse/templates.py\u001b[0m in \u001b[0;36mget_default_value\u001b[0;34m(self, key_name)\u001b[0m\n\u001b[1;32m     77\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0mhasattr\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m'default'\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;32mor\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdefault\u001b[0m \u001b[0;32mis\u001b[0m \u001b[0mREQUIRED\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     78\u001b[0m             \u001b[0;31m# The value is required. A missing value is an error.\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 79\u001b[0;31m             \u001b[0;32mraise\u001b[0m \u001b[0mexceptions\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mNotFoundError\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34mu\"{} not found\"\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mformat\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mkey_name\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     80\u001b[0m         \u001b[0;31m# The value is not required.\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     81\u001b[0m         \u001b[0;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdefault\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mNotFoundError\u001b[0m: plot.aspect not found"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<scipp.DataArray>\n",
+       "Dimensions: Sizes[spectrum:4, wavelength:3648, ]\n",
+       "Coordinates:\n",
+       "  integration_time            int32            [µs]  (spectrum)  [10000, 10000, 10000, 10000]\n",
+       "  is_dark                      bool           [None]  (spectrum)  [False, False, True, False]\n",
+       "  is_data                      bool           [None]  (spectrum)  [True, True, False, False]\n",
+       "  is_reference                 bool           [None]  (spectrum)  [False, False, False, True]\n",
+       "  time                        int64           [None]  (spectrum)  [1646685692000000, 1646685692000000, 1646685692000000, 1646685692000000]\n",
+       "  wavelength                float32             [nm]  (wavelength)  [195.674, 195.938, ..., 1047.73, 1047.93]\n",
+       "Data:\n",
+       "                            float32         [counts]  (spectrum, wavelength)  [0.316616, 0.316411, ..., 0.309243, 0.309243]\n"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "uv"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "scippneutron",
+   "language": "python",
+   "name": "scippneutron"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.12"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
I would like to make the following suggestion to the LoKI Nexus file concerning the NUrF sample environment.
The entries uv and fluo are of NXdata class. Currently the time unit is in micro-seconds (us) for the time parameters because the data I have uses this unit. 
I suggest to introduce an image similar to NXtomo. 0=sample, 2=dark field, 4=reference (buffer only) for the spectroscopy part. 
I created an array, where the each spectra is stored in columns.
The example data I have is not 100% perfect, so the final code will need adjustments when tested with real data from the new NUrF setup at LoKI.